### PR TITLE
Consistent indentation in `lem.asd`.

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -4,7 +4,7 @@
                "trivial-gray-streams"
                "trivial-types"
                "cl-ppcre"
-	       "micros"
+               "micros"
                "inquisitor"
                "babel"
                "bordeaux-threads"


### PR DESCRIPTION
Fix the indentation for one of the dependencies in the `lem.asd` file.